### PR TITLE
test(cli): add integration tests to the CLI

### DIFF
--- a/cli/index.test.ts
+++ b/cli/index.test.ts
@@ -1,0 +1,74 @@
+import { describe, test, expect } from "bun:test";
+
+const run = (...args: string[]) =>
+  Bun.spawn(["bun", "cli/index.ts", ...args], {
+    cwd: import.meta.dir + "/..",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+const collect = async (proc: ReturnType<typeof run>) => {
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  const exitCode = await proc.exited;
+  return { stdout, stderr, exitCode };
+};
+
+describe("CLI", () => {
+  describe("help", () => {
+    test("prints help with no arguments", async () => {
+      const { stdout, exitCode } = await collect(run());
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("Usage:");
+      expect(stdout).toContain("contextrie ingest");
+    });
+
+    test("prints help with --help", async () => {
+      const { stdout, exitCode } = await collect(run("--help"));
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("Usage:");
+    });
+
+    test("prints help with -h", async () => {
+      const { stdout, exitCode } = await collect(run("-h"));
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("Usage:");
+    });
+  });
+
+  describe("version", () => {
+    test("prints version with --version", async () => {
+      const { stdout, exitCode } = await collect(run("--version"));
+      expect(exitCode).toBe(0);
+      expect(stdout).toMatch(/contextrie v\d+\.\d+\.\d+/);
+    });
+
+    test("prints version with -v", async () => {
+      const { stdout, exitCode } = await collect(run("-v"));
+      expect(exitCode).toBe(0);
+      expect(stdout).toMatch(/contextrie v\d+\.\d+\.\d+/);
+    });
+
+    test("prints version with version command", async () => {
+      const { stdout, exitCode } = await collect(run("version"));
+      expect(exitCode).toBe(0);
+      expect(stdout).toMatch(/contextrie v\d+\.\d+\.\d+/);
+    });
+  });
+
+  describe("unknown command", () => {
+    test("exits with error for unknown command", async () => {
+      const { stderr, exitCode } = await collect(run("bogus"));
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain("Unknown command: bogus");
+    });
+  });
+
+  describe("ingest", () => {
+    test("exits with error when no files provided", async () => {
+      const { stderr, exitCode } = await collect(run("ingest"));
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain("No files provided");
+    });
+  });
+});

--- a/contributing.md
+++ b/contributing.md
@@ -21,6 +21,15 @@ bun run lint         # Run ESLint
 bun run lint:fix     # Auto-fix lint issues
 ```
 
+## Testing
+
+```bash
+bun test              # All tests
+bun test cli          # Just CLI tests
+```
+
+Test files live alongside source files using the `*.test.ts` convention.
+
 ## Project Structure
 
 ```

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "contextrie": "./dist/cli/index.js"
   },
   "scripts": {
+    "test": "bun test",
     "dev": "bun --hot ./index.ts",
     "build": "tsc -p tsconfig.build.json",
     "prepublishOnly": "bun run build",


### PR DESCRIPTION
Run `bun test` or `bun test cli`
```
bun test v1.1.26 (0a37423b)

cli/index.test.ts:
✓ CLI > help > prints help with no arguments [93.03ms]
✓ CLI > help > prints help with --help [50.10ms]
✓ CLI > help > prints help with -h [50.12ms]
✓ CLI > version > prints version with --version [48.71ms]
✓ CLI > version > prints version with -v [49.00ms]
✓ CLI > version > prints version with version command [48.82ms]
✓ CLI > unknown command > exits with error for unknown command [51.53ms]
✓ CLI > ingest > exits with error when no files provided [53.54ms]

 8 pass
 0 fail
 17 expect() calls
Ran 8 tests across 1 files. [547.00ms]
```