### PR TITLE
docs: add .env.example file and environment setup instructions

### DIFF
--- a/demo/.env.example
+++ b/demo/.env.example
@@ -1,0 +1,4 @@
+# OpenAI Configuration
+# Required for running the demo
+# Get your API key from https://platform.openai.com/api-keys
+OPENAI_API_KEY=your_openai_api_key_here

--- a/demo/README.md
+++ b/demo/README.md
@@ -60,6 +60,15 @@ const openai = createOpenAI({ apiKey: process.env.OPENAI_API_KEY });
 const model = openai("gpt-5.2-chat");
 ```
 
+## Environment Setup
+
+If you're using the OpenAI option, copy the example environment file and add your API key:
+```bash
+cp .env.example .env
+```
+
+Then open `.env` and replace `your_openai_api_key_here` with your actual key from https://platform.openai.com/api-keys
+
 ## Output
 
 The demo outputs:


### PR DESCRIPTION
Closes #35

## Changes
 Added `demo/.env.example` with the required `OPENAI_API_KEY` variable, placeholder value, and documentation comment
 Updated `demo/README.md` with an Environment Setup section explaining how to copy and configure the file

## Why this?
New contributors need to know what environment variables are required to run the demo. This makes onboarding faster and reduces confusion.