### PR TITLE
Add coding-agent harness stub

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -6,6 +6,8 @@
 
 Planned. This directory defines the benchmark direction. It does not yet ship a runnable harness.
 
+The coding agent harness stub currently lives in `../coding-agent/README.md`.
+
 ## What this is
 
 `benchmarks` is the repo place for defining how Contextrie should be evaluated against generic agent coding workflows.

--- a/coding-agent/README.md
+++ b/coding-agent/README.md
@@ -1,0 +1,13 @@
+# coding-agent
+
+> Stub for the Contextrie coding agent harness.
+
+## Status
+
+Stub. This directory is the planned home for the coding agent harness.
+
+## Intent
+
+- define the harness shape
+- document the evaluation flow
+- land implementation details here as they are built

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,4 +6,5 @@ Docs site for Contextrie. Work in progress.
 
 - present the product clearly
 - document the package layout
+- describe `coding-agent` as the coding agent harness
 - stay visually aligned with the main repo

--- a/docs/src/routes/+page.svelte
+++ b/docs/src/routes/+page.svelte
@@ -29,6 +29,7 @@
 			<ul>
 				<li><strong>core</strong> for contracts and source primitives</li>
 				<li><strong>cli</strong> for the command-line wrapper</li>
+				<li><strong>coding-agent</strong> for the coding agent harness</li>
 				<li><strong>docs</strong> for the public-facing explanation layer</li>
 			</ul>
 		</article>

--- a/readme.md
+++ b/readme.md
@@ -123,6 +123,7 @@ Most agent systems fail gradually, not instantly. They accumulate irrelevant con
 - `@contextrie/core`: published now, TypeScript contracts and core agents
 - `@contextrie/parsers`: published now, file parsers for `.csv`, `.md`, and `.txt`
 - `@contextrie/cli`: published npm CLI for indexing local sources and composing task-specific context
+- `coding-agent`: planned coding agent harness with a stub README in `coding-agent/README.md`
 - `benchmarks`: benchmark definitions and protocol for evaluating agent workflows
 - `docs`: documentation site in progress
 - `python`: Python core library with mirrored source and agent contracts
@@ -141,13 +142,13 @@ Start with [`examples/demo/README.md`](./examples/demo/README.md) for the smalle
 
 Use [`examples/parsers/README.md`](./examples/parsers/README.md) for a standalone package example that consumes `@contextrie/parsers` and parses local files into Contextrie sources.
 
-Benchmark planning lives in [`benchmarks/README.md`](./benchmarks/README.md).
+Benchmark planning lives in [`benchmarks/README.md`](./benchmarks/README.md), and the coding agent harness stub lives in [`coding-agent/README.md`](./coding-agent/README.md).
 
 ---
 
 ## Roadmap 🚧
 
-- Benchmark harness and eval protocol
+- Coding agent harness and eval protocol
 - Hosted docs site
 - CLI binary distribution
 - More examples and eval coverage
@@ -172,6 +173,7 @@ Benchmark planning lives in [`benchmarks/README.md`](./benchmarks/README.md).
 ├─ assets/        Visuals and branding
 ├─ benchmarks/    Benchmark protocol and future harness
 ├─ cli/           Published npm CLI package
+├─ coding-agent/  Coding agent harness stub and future implementation
 ├─ core/          TypeScript library (npm)
 ├─ docs/          SvelteKit documentation site
 ├─ examples/      Minimal examples


### PR DESCRIPTION
## Summary
- add a stub README under `coding-agent/`
- describe `coding-agent` as the coding agent harness across repo docs
- link benchmark and repo overview docs to the new harness stub
